### PR TITLE
fix visibility error in Ajax request admin grid

### DIFF
--- a/app/code/community/Inchoo/FeaturedProducts/Block/Adminhtml/Edit/Renderer/Visibility.php
+++ b/app/code/community/Inchoo/FeaturedProducts/Block/Adminhtml/Edit/Renderer/Visibility.php
@@ -21,7 +21,7 @@ class Inchoo_FeaturedProducts_Block_Adminhtml_Edit_Renderer_Visibility extends M
         
         $this->_values = Mage::getModel('catalog/product_visibility')->getOptionArray();
         
-        $html = $this->_values[$row->getData($this->getColumn()->getIndex())];
+        $html = $this->_values[(int)$row->getData($this->getColumn()->getIndex())];
       
         return $html;
     }


### PR DESCRIPTION
In magento 1.9.1.1, when I search in grid for some product, I get *Notice: Undefined index: 4.0000  in */srv/www/htdocs/vhosts/magento/htdocs/app/code/community/Inchoo/FeaturedProducts/Block/Adminhtml/Edit/Renderer/Visibility.php on line 24*. Visibility product  was Catalog, Search.
Type casting to int the value, You should solve the issue.