### PR TITLE
fix: checkboxes is not accessible after filter applied to grid. Magento ver. 1.9.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [![Inchoo](http://inchoo.net/wp-content/themes/inchoo4/images/logo.svg)](http://inchoo.net) [Featured Products](http://inchoo.net/ecommerce/magento/featured-products-on-magento-frontpage/)
+# [Fix for grid checkboxes included] [Featured Products](http://inchoo.net/ecommerce/magento/featured-products-on-magento-frontpage/)
 
 (Revamped version for new Magento CE & EE : for Magento CE lower that 1.6 and EE lower that 1.11, please use [older releases](https://github.com/buric/Inchoo_FeaturedProducts/branches).)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# [Fix for grid checkboxes included] [Featured Products](http://inchoo.net/ecommerce/magento/featured-products-on-magento-frontpage/)
+# [Fix for grid checkboxes included] 
+# [Featured Products](http://inchoo.net/ecommerce/magento/featured-products-on-magento-frontpage/)
 
-(Revamped version for new Magento CE & EE : for Magento CE lower that 1.6 and EE lower that 1.11, please use [older releases](https://github.com/buric/Inchoo_FeaturedProducts/branches).)
+Updated version of Inchoo_FeaturedProducts extension, with fix of grid checkboxes. 
+In case filter applied to grid checkboxes become inaccessible.
 
 ## About
 
@@ -30,6 +32,9 @@ Configuration Options You will be able to choose layout for Featured product lis
 - Enable Catalog Categoryes flat and save them
 
 ## Changelog
+
+### Version [1.2.4]
+ 1. Updated version of Inchoo_FeaturedProducts extension, with fix of grid checkboxes. In case filter applied to grid, checkboxes become inaccessible.
 
 ### Version [1.2.3](https://github.com/buric/Inchoo_FeaturedProducts/tree/1.2.3)
  1. Reorganized System->Configuration section - everything from Inchoo is under "Inchoo" tab now

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# [Fix for grid checkboxes included] 
-# [Featured Products](http://inchoo.net/ecommerce/magento/featured-products-on-magento-frontpage/)
+# [![Inchoo](http://inchoo.net/wp-content/themes/inchoo4/images/logo.svg)](http://inchoo.net) [Featured Products](http://inchoo.net/ecommerce/magento/featured-products-on-magento-frontpage/)
 
-Updated version of Inchoo_FeaturedProducts extension, with fix of grid checkboxes. 
-In case filter applied to grid checkboxes become inaccessible.
+(Revamped version for new Magento CE & EE : for Magento CE lower that 1.6 and EE lower that 1.11, please use [older releases](https://github.com/buric/Inchoo_FeaturedProducts/branches).)
 
 ## About
 
@@ -32,9 +30,6 @@ Configuration Options You will be able to choose layout for Featured product lis
 - Enable Catalog Categoryes flat and save them
 
 ## Changelog
-
-### Version [1.2.4]
- 1. Updated version of Inchoo_FeaturedProducts extension, with fix of grid checkboxes. In case filter applied to grid, checkboxes become inaccessible.
 
 ### Version [1.2.3](https://github.com/buric/Inchoo_FeaturedProducts/tree/1.2.3)
  1. Reorganized System->Configuration section - everything from Inchoo is under "Inchoo" tab now

--- a/app/code/community/Inchoo/FeaturedProducts/Block/Adminhtml/Edit/Grid.php
+++ b/app/code/community/Inchoo/FeaturedProducts/Block/Adminhtml/Edit/Grid.php
@@ -7,6 +7,7 @@
  * @modified    Mladen Lotar <mladen.lotar@surgeworks.com>, Vedran Subotic <vedran.subotic@surgeworks.com>
  */
 class Inchoo_FeaturedProducts_Block_Adminhtml_Edit_Grid extends Mage_Adminhtml_Block_Widget_Grid {
+
     public function __construct() {
         parent::__construct();
 
@@ -175,10 +176,7 @@ class Inchoo_FeaturedProducts_Block_Adminhtml_Edit_Grid extends Mage_Adminhtml_B
 
     public function getGridUrl() {
         return $this->getUrl('*/featured/index', array('_current' => true));
-        //return $this->getUrl('*/*/grid', array('_current' => true));
     }
-
-
 
     protected function _getSelectedProducts($json = false) {
         $temp = $this->getRequest()->getPost('featured_ids');
@@ -301,6 +299,7 @@ class Inchoo_FeaturedProducts_Block_Adminhtml_Edit_Grid extends Mage_Adminhtml_B
         }
    
 		$("in_featured_products").value = checkBoxes.toQueryString();
+		console.log("Products", checkBoxes);
 	   	$gridName.reloadParams = {'featured_ids':checkBoxes.toQueryString()};    
     }
     
@@ -312,8 +311,6 @@ EndHTML;
         return $html;
     }
 
-
-
     private function _appendHtml() {
         $html = '<script type="text/javascript">	
 		var checkBoxes = $H();
@@ -322,20 +319,21 @@ EndHTML;
         	var everycheckbox = $$("#inchoo_featured_products_table tbody input.checkbox");
 		
 		checkbox_all.observe("click", function(event) {
-            if(checkbox_all.checked)
-            {
-                        everycheckbox.each(function(element, index) {
-                            
-                checkBoxes.set(element.value, 1)
-                            
-                    });
-            } else
-                            {
-                                everycheckbox.each(function(element, index) {
-                                checkBoxes.set(element.value, 0)
+		
+		if(checkbox_all.checked)
+		{
+                	everycheckbox.each(function(element, index) {
+                        
+			checkBoxes.set(element.value, 1)
+                        
                 });
-                    }
-            $("in_featured_products").value = checkBoxes.toQueryString();
+                    } else
+                        {
+                            everycheckbox.each(function(element, index) {
+                            checkBoxes.set(element.value, 0)
+			});
+                }
+    	$("in_featured_products").value = checkBoxes.toQueryString();
 		});	
 
         </script>';

--- a/app/code/community/Inchoo/FeaturedProducts/Block/Adminhtml/Edit/Grid.php
+++ b/app/code/community/Inchoo/FeaturedProducts/Block/Adminhtml/Edit/Grid.php
@@ -7,13 +7,12 @@
  * @modified    Mladen Lotar <mladen.lotar@surgeworks.com>, Vedran Subotic <vedran.subotic@surgeworks.com>
  */
 class Inchoo_FeaturedProducts_Block_Adminhtml_Edit_Grid extends Mage_Adminhtml_Block_Widget_Grid {
-
     public function __construct() {
         parent::__construct();
 
         $this->setId('inchoo_featured_products');
         $this->setDefaultSort('entity_id');
-        $this->setUseAjax(true);
+        $this->setUseAjax(false);
 
         $this->setRowClickCallback('FeaturedRowClick');
     }
@@ -175,8 +174,11 @@ class Inchoo_FeaturedProducts_Block_Adminhtml_Edit_Grid extends Mage_Adminhtml_B
     }
 
     public function getGridUrl() {
-        return $this->getUrl('*/*/grid', array('_current' => true));
+        return $this->getUrl('*/featured/index', array('_current' => true));
+        //return $this->getUrl('*/*/grid', array('_current' => true));
     }
+
+
 
     protected function _getSelectedProducts($json = false) {
         $temp = $this->getRequest()->getPost('featured_ids');
@@ -299,7 +301,6 @@ class Inchoo_FeaturedProducts_Block_Adminhtml_Edit_Grid extends Mage_Adminhtml_B
         }
    
 		$("in_featured_products").value = checkBoxes.toQueryString();
-		console.log("Products", checkBoxes);
 	   	$gridName.reloadParams = {'featured_ids':checkBoxes.toQueryString()};    
     }
     
@@ -311,6 +312,8 @@ EndHTML;
         return $html;
     }
 
+
+
     private function _appendHtml() {
         $html = '<script type="text/javascript">	
 		var checkBoxes = $H();
@@ -319,21 +322,20 @@ EndHTML;
         	var everycheckbox = $$("#inchoo_featured_products_table tbody input.checkbox");
 		
 		checkbox_all.observe("click", function(event) {
-		
-		if(checkbox_all.checked)
-		{
-                	everycheckbox.each(function(element, index) {
-                        
-			checkBoxes.set(element.value, 1)
-                        
+            if(checkbox_all.checked)
+            {
+                        everycheckbox.each(function(element, index) {
+                            
+                checkBoxes.set(element.value, 1)
+                            
+                    });
+            } else
+                            {
+                                everycheckbox.each(function(element, index) {
+                                checkBoxes.set(element.value, 0)
                 });
-                    } else
-                        {
-                            everycheckbox.each(function(element, index) {
-                            checkBoxes.set(element.value, 0)
-			});
-                }
-    	$("in_featured_products").value = checkBoxes.toQueryString();
+                    }
+            $("in_featured_products").value = checkBoxes.toQueryString();
 		});	
 
         </script>';


### PR DESCRIPTION
fix: checkboxes is not accessible after filter applied to grid. Magento ver. 1.9.1.1