### PR TITLE
fix: checkboxes is not accessible after filter applied

### DIFF
--- a/app/code/community/Inchoo/FeaturedProducts/Block/Adminhtml/Edit/Grid.php
+++ b/app/code/community/Inchoo/FeaturedProducts/Block/Adminhtml/Edit/Grid.php
@@ -13,7 +13,7 @@ class Inchoo_FeaturedProducts_Block_Adminhtml_Edit_Grid extends Mage_Adminhtml_B
 
         $this->setId('inchoo_featured_products');
         $this->setDefaultSort('entity_id');
-        $this->setUseAjax(true);
+        $this->setUseAjax(false);
 
         $this->setRowClickCallback('FeaturedRowClick');
     }
@@ -175,7 +175,7 @@ class Inchoo_FeaturedProducts_Block_Adminhtml_Edit_Grid extends Mage_Adminhtml_B
     }
 
     public function getGridUrl() {
-        return $this->getUrl('*/*/grid', array('_current' => true));
+        return $this->getUrl('*/featured/index', array('_current' => true));
     }
 
     protected function _getSelectedProducts($json = false) {


### PR DESCRIPTION
fix: checkboxes is not accessible after filter applied to Featured Products admin grid. Magento ver. 1.9.1.1