### PR TITLE
Changed product grid listing code to match the new RWD design

### DIFF
--- a/app/design/frontend/base/default/template/inchoo/featuredproducts/block_featured_products.phtml
+++ b/app/design/frontend/base/default/template/inchoo/featuredproducts/block_featured_products.phtml
@@ -8,10 +8,10 @@
 ?>
 <?php $image_size = (int) Mage::getStoreConfig("featuredproducts/cmspage/max_image_dimension") ?>
 <?php if (($_products = $this->getProductCollection()) && $_products->getSize()): ?>
-    <h3><?php echo $this->__($this->getBlockLabel()) ?></h3>
-    <table border="0" cellspacing="0">
+    <div class="featuredProducts">
+    <h2><?php echo $this->__($this->getBlockLabel()) ?></h2>
+    <ul class="products-grid products-grid--max-6-col first last odd">
 
-        <tbody>
 
             <?php
             $i = 0;
@@ -19,37 +19,27 @@
             foreach ($_products->getItems() as $_product):
                 ?>
 
-                    <?php if ($i == 0): ?>
-                        <?php $row++; ?>
-                    <tr class="<?php echo (($row % 2) > 0) ? 'odd' : 'even' ?>">
-        <?php endif; ?>
-                    <td>
 
-                        <a href="<?php echo $_product->getProductUrl() ?>" title="<?php echo $this->htmlEscape($_product->getName()) ?>">
-                            <img class="product-img" src="<?php echo $this->helper('catalog/image')->init($_product, 'small_image')->resize($image_size, $image_size) ?>" alt="<?php echo $this->htmlEscape($_product->getName()) ?>" />
+                    <li class="item last">
+                        <a href="<?php echo $_product->getProductUrl() ?>" title="<?php echo $this->htmlEscape($_product->getName()) ?>" class="product-image">
+                            <img src="<?php echo $this->helper('catalog/image')->init($_product, 'small_image')->resize($image_size, $image_size) ?>" alt="<?php echo $this->htmlEscape($_product->getName()) ?>">
                         </a>
-                        <div class="product-description">
-                            <p>
-                                <a href="<?php echo $_product->getProductUrl() ?>" title="<?php echo $this->htmlEscape($_product->getName()) ?>)">
-                            <?php echo $this->htmlEscape($_product->getName()) ?>
-                                </a>
-                            </p>
-                            <?php echo $this->getReviewsSummaryHtml($_product, 'short') ?>
+                        <div class="product-info">
+                            <h2 class="product-name"><a href="<?php echo $_product->getProductUrl() ?>" title="<?php echo $this->htmlEscape($_product->getName()) ?>"><?php echo $this->htmlEscape($_product->getName()) ?></a></h2>
+                            <div class="actions">
+                                <?php if (Mage::getStoreConfig('featuredproducts/general/price_visible')): ?>
 
-                            <?php if (Mage::getStoreConfig('featuredproducts/general/price_visible')): ?>
+                                    <?php echo $this->getPriceHtml($_product, true, '-new') ?>
 
-                                <?php echo $this->getPriceHtml($_product, true, '-new') ?>
-
-                                <?php if ($_product->isSaleable()): ?>
-                                    <button type="button" class="button btn-cart" onclick="setLocation('<?php echo $this->getAddToCartUrl($_product) ?>')"><span><span><?php echo $this->__('Add to Cart') ?></span></span></button>
-                                <?php else: ?>
-                                    <div class="out-of-stock"><?php echo $this->__('Out of stock') ?></div>
+                                    <?php if ($_product->isSaleable()){
+                                        <button type="button" class="button btn-cart" onclick="setLocation('<?php echo $this->getAddToCartUrl($_product) ?>')"><span><span><?php echo $this->__('Add to Cart') ?></span></span></button>
                                 <?php endif; ?>
 
-        <?php endif; ?>
-
+                            </div>
                         </div>
-                    </td>
+                    </li>
+
+
 
                     <?php $i++;
                     if ($i == $this->getItemsPerRow()):
@@ -59,7 +49,6 @@
         <?php endif; ?>
     <?php endforeach; ?>
 
-        </tbody>
-
-    </table>
+    </ul>
+    </div>
 <?php endif; ?>


### PR DESCRIPTION
product grid now resembles the HTML used by the default Magento RWD design package.
This means the javascript to match the product column heights will work.
You will need to alter the class `products-grid--max-6-col` in order to display the correct number of products per row (I think max is 6).
Some features such as configurable swatches will not work.